### PR TITLE
Polish book cover: text-cover title layout + minute sub-dial center

### DIFF
--- a/book/Figures/cover-new-inverse.svg
+++ b/book/Figures/cover-new-inverse.svg
@@ -383,7 +383,9 @@
         <g transform="translate(400,556) rotate(132)"><rect x="-1.6" y="-24" width="3.2" height="24" rx="1.6" fill="#F7F3E8"/></g>
         <g transform="translate(400,556) rotate(264)"><rect x="-1.6" y="-24" width="3.2" height="24" rx="1.6" fill="#4ABCD8"/></g>
       </g>
+      <circle cx="400" cy="556" r="5" fill="none" stroke="#F7F3E8" stroke-width="0.6"/>
       <circle cx="400" cy="556" r="3" fill="#C8A800"/>
+      <circle cx="400" cy="556" r="1.5" fill="#F7F3E8"/>
     </g>
 
     <!-- ── THREE STOPWATCH HANDS — equal length/width, distinct colors ── -->

--- a/book/Figures/cover-new-text.svg
+++ b/book/Figures/cover-new-text.svg
@@ -436,32 +436,20 @@
   </g><!-- end IT19 artwork translate -->
 
   <!-- ── IT19 TEXT OVERLAY ── -->
-  <rect x="267" y="229" width="533" height="400" fill="#1A2434" opacity="0.81"/>
-  <rect x="267" y="229" width="533" height="4" fill="#FCD3B6"/>
-  <rect x="267" y="625" width="533" height="4" fill="#FCD3B6"/>
-  <text x="285" y="256"
-    fill="#7A8BA0" font-size="10.5" font-family="DejaVu Sans"
-    letter-spacing="1.4">MACHINE LEARNING IN SURVIVAL ANALYSIS</text>
-  <text x="285" y="318"
+  <rect x="267" y="286" width="533" height="351" fill="#1A2434" opacity="0.81"/>
+  <rect x="267" y="286" width="533" height="4" fill="#FCD3B6"/>
+  <rect x="267" y="633" width="533" height="4" fill="#FCD3B6"/>
+  <text x="285" y="375"
     fill="#F7F3E8" font-size="42" font-family="DejaVu Sans" font-weight="bold"
-    text-anchor="start" textLength="210" lengthAdjust="spacingAndGlyphs">MACHINE</text>
-  <text x="782" y="318"
+    text-anchor="start" textLength="497" lengthAdjust="spacingAndGlyphs">MACHINE LEARNING</text>
+  <text x="285" y="429"
     fill="#F7F3E8" font-size="42" font-family="DejaVu Sans" font-weight="bold"
-    text-anchor="end" textLength="210" lengthAdjust="spacingAndGlyphs">SURVIVAL</text>
-  <text x="285" y="372"
-    fill="#F7F3E8" font-size="42" font-family="DejaVu Sans" font-weight="bold"
-    text-anchor="start" textLength="210" lengthAdjust="spacingAndGlyphs">LEARNING</text>
-  <text x="782" y="372"
-    fill="#F7F3E8" font-size="42" font-family="DejaVu Sans" font-weight="bold"
-    text-anchor="end" textLength="210" lengthAdjust="spacingAndGlyphs">ANALYSIS</text>
-  <line x1="285" y1="396" x2="782" y2="396"
+    text-anchor="start" textLength="497" lengthAdjust="spacingAndGlyphs">SURVIVAL ANALYSIS</text>
+  <line x1="285" y1="453" x2="782" y2="453"
     stroke="#4A6A8A" stroke-width="0.8" opacity="0.55"/>
-  <text x="285" y="420"
-    fill="#C8A800" font-size="10" font-family="DejaVu Sans"
-    letter-spacing="2.2">EDITED BY</text>
-  <text x="285" y="447"
+  <text x="285" y="504"
     fill="#F7F3E8" font-size="17" font-family="DejaVu Sans">Raphael Sonabend</text>
-  <text x="285" y="472"
+  <text x="285" y="529"
     fill="#F7F3E8" font-size="17" font-family="DejaVu Sans">Andreas Bender</text>
 
 </svg>

--- a/book/Figures/cover-new-text.svg
+++ b/book/Figures/cover-new-text.svg
@@ -392,7 +392,9 @@
         <g transform="translate(400,556) rotate(132)"><rect x="-1.6" y="-24" width="3.2" height="24" rx="1.6" fill="#F7F3E8"/></g>
         <g transform="translate(400,556) rotate(264)"><rect x="-1.6" y="-24" width="3.2" height="24" rx="1.6" fill="#4ABCD8"/></g>
       </g>
+      <circle cx="400" cy="556" r="5" fill="none" stroke="#F7F3E8" stroke-width="0.6"/>
       <circle cx="400" cy="556" r="3" fill="#C8A800"/>
+      <circle cx="400" cy="556" r="1.5" fill="#F7F3E8"/>
     </g>
 
     <!-- ── THREE STOPWATCH HANDS — equal length/width, distinct colors ── -->

--- a/book/Figures/cover-new-text.svg
+++ b/book/Figures/cover-new-text.svg
@@ -436,20 +436,20 @@
   </g><!-- end IT19 artwork translate -->
 
   <!-- ── IT19 TEXT OVERLAY ── -->
-  <rect x="267" y="286" width="533" height="351" fill="#1A2434" opacity="0.81"/>
-  <rect x="267" y="286" width="533" height="4" fill="#FCD3B6"/>
+  <rect x="267" y="261" width="533" height="376" fill="#1A2434" opacity="0.81"/>
+  <rect x="267" y="261" width="533" height="4" fill="#FCD3B6"/>
   <rect x="267" y="633" width="533" height="4" fill="#FCD3B6"/>
-  <text x="285" y="375"
+  <text x="285" y="350"
     fill="#F7F3E8" font-size="42" font-family="DejaVu Sans" font-weight="bold"
     text-anchor="start" textLength="497" lengthAdjust="spacingAndGlyphs">MACHINE LEARNING</text>
-  <text x="285" y="429"
+  <text x="285" y="404"
     fill="#F7F3E8" font-size="42" font-family="DejaVu Sans" font-weight="bold"
     text-anchor="start" textLength="497" lengthAdjust="spacingAndGlyphs">SURVIVAL ANALYSIS</text>
-  <line x1="285" y1="453" x2="782" y2="453"
+  <line x1="285" y1="428" x2="782" y2="428"
     stroke="#4A6A8A" stroke-width="0.8" opacity="0.55"/>
-  <text x="285" y="504"
+  <text x="285" y="479"
     fill="#F7F3E8" font-size="17" font-family="DejaVu Sans">Raphael Sonabend</text>
-  <text x="285" y="529"
+  <text x="285" y="504"
     fill="#F7F3E8" font-size="17" font-family="DejaVu Sans">Andreas Bender</text>
 
 </svg>

--- a/book/Figures/cover-new.svg
+++ b/book/Figures/cover-new.svg
@@ -378,7 +378,9 @@
         <g transform="translate(400,556) rotate(132)"><rect x="-1.6" y="-24" width="3.2" height="24" rx="1.6" fill="#F7F3E8"/></g>
         <g transform="translate(400,556) rotate(264)"><rect x="-1.6" y="-24" width="3.2" height="24" rx="1.6" fill="#4ABCD8"/></g>
       </g>
+      <circle cx="400" cy="556" r="5" fill="none" stroke="#F7F3E8" stroke-width="0.6"/>
       <circle cx="400" cy="556" r="3" fill="#C8A800"/>
+      <circle cx="400" cy="556" r="1.5" fill="#F7F3E8"/>
     </g>
 
     <!-- ── THREE STOPWATCH HANDS — equal length/width, distinct colors ── -->


### PR DESCRIPTION
Cover polish on top of #199.

**Text cover (`cover-new-text.svg`)**
- Two-line, edge-justified title: **MACHINE LEARNING** / **SURVIVAL ANALYSIS**
- Removed the small subtitle line and the "EDITED BY" label
- Resized/repositioned the text panel (bottom just below the cover midline, generous padding)

**All clock variants (`cover-new.svg`, `cover-new-text.svg`, `cover-new-inverse.svg`)**
- Added a white center dot and a thin white ring to the minutes sub-dial, mirroring the seconds-face center detail