### PR TITLE
Preface: remove stray genAI paragraph

### DIFF
--- a/book/index.qmd
+++ b/book/index.qmd
@@ -117,11 +117,6 @@ Machine learning\index{machine learning} literature on the other hand focuses on
 In recent years there has been increasing overlap between survival analysis and machine learning, but there appears to still be a substantial gap in the knowledge and skills required to integrate the two fields. 
 This book aims to further bridge the gap by introducing the key fundamental concepts of both fields before combining them into _machine learning survival analysis_\index{machine learning survival analysis}.
 
-This is especially true in survival analysis where the slower adoption of machine learning means the field could leapfrog to genAI approaches.
-However, genAI is a sub-field of machine learning and the approaches in this book directly apply to newer methods.
-This is especially true for the underlying theory (Part I), evaluation\index{evaluation} (Part II), and reductions\index{reduction} (Part IV).
-Moreover, when prompting genAI tools to solve a survival analysis problem, practically they almost always write code that leverages machine learning models, therefore understanding these models (Part II) is vital to ensure model explainability\index{explainability}.
-
 ## Overview of the book
 
 This book is intended to fill a gap in the literature by providing a comprehensive introduction to machine learning in the survival setting.


### PR DESCRIPTION
Removes a leftover paragraph in the preface that began "This is especially true in survival analysis…" with no preceding setup — missed during the earlier preface copyedit (#179).